### PR TITLE
Bump dependencies and use `^` instead of `~`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -506,9 +506,9 @@
       "dev": true
     },
     "listen": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listen/-/listen-0.4.0.tgz",
-      "integrity": "sha1-xS3W86X79NhR4vjfPUoJr67lSQ0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listen/-/listen-1.0.1.tgz",
+      "integrity": "sha1-/u3j1ah0xTwihNPDWXpfxa/HTkM="
     },
     "lodash": {
       "version": "4.17.4",
@@ -523,9 +523,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.2.10.tgz",
-      "integrity": "sha1-1f1oJxyq5hxV0pHQe9UDTP9ec+4="
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -536,8 +536,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -546,9 +545,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
-      "integrity": "sha1-K7xbRMMhg3aTq278rb1G7ZRiEf4="
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "ms": {
       "version": "2.0.0",
@@ -557,9 +556,9 @@
       "dev": true
     },
     "mustache": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-0.7.3.tgz",
-      "integrity": "sha1-JI1o0LEFA5eEj6Y0wkRsGPMEkOk="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
+      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -604,9 +603,9 @@
       "dev": true
     },
     "optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY="
     },
     "optionator": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "url": "https://github.com/mantoni/blogdown.git"
   },
   "dependencies": {
-    "marked": "~0.2.8",
-    "mustache": "~0.7.2",
-    "listen": "~0.4.0",
-    "moment": "~2.0.0",
-    "optimist": "~0.3.7"
+    "listen": "^1.0.1",
+    "marked": "^0.3.6",
+    "moment": "^2.18.1",
+    "mustache": "^2.3.0",
+    "optimist": "^0.6.1"
   },
   "devDependencies": {
     "eslint": "^3.19.0",


### PR DESCRIPTION
Also part of #5, use more modern versions of the external libraries.